### PR TITLE
Add function for generating keypair from a seed

### DIFF
--- a/src/cbits/include/ed25519.h
+++ b/src/cbits/include/ed25519.h
@@ -8,6 +8,8 @@
 #define crypto_sign_IMPLEMENTATION crypto_sign_ed25519_IMPLEMENTATION
 #define crypto_sign_VERSION crypto_sign_ed25519_VERSION
 
+int ed25519_sign_seed_keypair(unsigned char *pk, unsigned char *sk,
+                              const unsigned char *seed);
 int ed25519_sign_keypair(unsigned char *pk,unsigned char *sk);
 int ed25519_sign(unsigned char *sm,unsigned long long *smlen,
                  const unsigned char *m,unsigned long long mlen,


### PR DESCRIPTION
I ended up using the libsodium version of this function, added [here](https://github.com/jedisct1/libsodium/commit/a821eae055712d1ebda6386ffb1295f26ef2555a).

A few comments:
1. I added this in two commits, one for the underlying C function, and one for the bindings. Let me know if you want me to squash these into one.
2. I didn't add a test because... well, I'm not really sure how to test this (also I can't run the tests at the moment, but the other two pull requests open at the moment fix this). If you can think of something, I'd be happy to try implement it.
