### PR TITLE
Depend on ghc-prim only for GHC 7.[24]

### DIFF
--- a/ed25519.cabal
+++ b/ed25519.cabal
@@ -60,9 +60,12 @@ flag no-donna
 
 library
   build-depends:
-    ghc-prim    >= 0.1 && < 0.5,
     base        >= 4   && < 5,
     bytestring  >= 0.9 && < 0.11
+
+  -- GHC.Generics lived in `ghc-prim` for GHC 7.2 & GHC 7.4
+  if impl(ghc >= 7.2 && < 7.6)
+    build-depends: ghc-prim == 0.2.*
 
   exposed-modules:
     Crypto.Sign.Ed25519


### PR DESCRIPTION
This fixes #10 and follows a `.cabal` pattern used by other packages
such as `deepseq`.
