### PR TITLE
Support stack LTS 8.1 (GHC 8.0.2)

### DIFF
--- a/ed25519.cabal
+++ b/ed25519.cabal
@@ -134,7 +134,7 @@ test-suite doctests
     build-depends:
       base      >= 4    && < 5,
       filepath  >= 1.0  && < 1.5,
-      directory >= 1.0  && < 1.3,
+      directory >= 1.0  && < 1.4,
       doctest   >= 0.10 && < 0.12,
       filemanip >= 0.3 && < 0.4,
       ed25519


### PR DESCRIPTION
Tests failed with 

```
Registering ed25519-0.0.5.0...
ed25519-0.0.5.0: test (suite: doctests)
               
Examples: 17  Tried: 17  Errors: 0  Failures: 00  Failures: 0
               
ed25519-0.0.5.0: test (suite: hlint)
               
I found more than one cabal_macros.h file?!?! Bailing!
```

But I don't think this is relevant.

cc @thoughtpolice 