### PR TITLE
Relax constraint on ghc-prim to support ghc-8.10.1

### DIFF
--- a/ed25519.cabal
+++ b/ed25519.cabal
@@ -61,7 +61,7 @@ flag no-donna
 
 library
   build-depends:
-    ghc-prim    >= 0.1 && < 0.6,
+    ghc-prim    >= 0.1 && < 0.7,
     base        >= 4   && < 5,
     bytestring  >= 0.9 && < 0.11
 


### PR DESCRIPTION
The new `ghc-prim` version 0.6.1 builds fine with this package, the Cabal file just needs to allow it.