### PR TITLE
allow ghc-prim-0.7 for ghc-9.0

### DIFF
--- a/ed25519.cabal
+++ b/ed25519.cabal
@@ -61,7 +61,7 @@ flag no-donna
 
 library
   build-depends:
-    ghc-prim    >= 0.1 && < 0.7,
+    ghc-prim    >= 0.1 && < 0.8,
     base        >= 4   && < 5,
     bytestring  >= 0.9 && < 0.11
 


### PR DESCRIPTION
This builds fine for me with `stack --resolver nightly build` (nightly is current ghc-9.0.2)