### PR TITLE
Support GHC 9.4

### DIFF
--- a/ed25519.cabal
+++ b/ed25519.cabal
@@ -61,7 +61,7 @@ flag no-donna
 
 library
   build-depends:
-    ghc-prim    >= 0.1 && < 0.9,
+    ghc-prim    >= 0.1 && < 0.10,
     base        >= 4   && < 5,
     bytestring  >= 0.9 && < 0.12
 
@@ -101,7 +101,7 @@ test-suite properties
     build-depends:
       base        >= 4   && < 5,
       bytestring  >= 0.9 && < 0.12,
-      QuickCheck  >= 2.4 && < 2.10,
+      QuickCheck  >= 2.4 && < 2.15,
       ed25519
 
 --
@@ -119,7 +119,7 @@ test-suite hlint
   else
     build-depends:
       base      >= 4   && < 5,
-      hlint     >= 1.7 && < 1.10,
+      hlint     >= 1.7 && < 3.6,
       filemanip >= 0.3 && < 0.4
 
 
@@ -136,7 +136,7 @@ test-suite doctests
       base      >= 4    && < 5,
       filepath  >= 1.0  && < 1.5,
       directory >= 1.0  && < 1.4,
-      doctest   >= 0.10 && < 0.12,
+      doctest   >= 0.10 && < 0.21,
       filemanip >= 0.3  && < 0.4,
       ed25519
 

--- a/src/Crypto/Sign/Ed25519.hs
+++ b/src/Crypto/Sign/Ed25519.hs
@@ -461,7 +461,7 @@ sign' :: SecretKey
       -- ^ Input message
       -> Signature
       -- ^ Message @'Signature'@, without the message
-sign' sk xs = dsign sk xs
+sign' = dsign
 {-# DEPRECATED sign' "@'sign''@ will be removed in a future release; use @'dsign'@ instead." #-}
 
 -- | Verify a message with a detached @'Signature'@ against a given
@@ -476,7 +476,7 @@ verify' :: PublicKey
         -- ^ Message @'Signature'@
         -> Bool
         -- ^ Verification result
-verify' pk xs sig = dverify pk xs sig
+verify' = dverify
 {-# DEPRECATED verify' "@'verify''@ will be removed in a future release; use @'dverify'@ instead." #-}
 
 --------------------------------------------------------------------------------

--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -22,4 +22,4 @@ getHsFiles = find (return True) (extension ==? ".hs")
 getCObjFiles :: FilePath -> IO [FilePath]
 getCObjFiles = find (return True) (isObj &&? isCorrectDir) where
   isObj = extension ==? ".o"
-  isCorrectDir = isInfixOf "build/src/cbits" `liftM` directory
+  isCorrectDir = isInfixOf "build/src/cbits" <$> directory

--- a/tests/hlint.hs
+++ b/tests/hlint.hs
@@ -15,7 +15,7 @@ main = do
 
   -- When we build, we might use cabal, stack, cabal new-build, etc..
   -- so find the cabal_macros.h file dynamically.
-  macros <- find (return True) ((== "cabal_macros.h") `liftM` fileName) "."
+  macros <- find (return True) ((== "cabal_macros.h") <$> fileName) "."
   case macros of
     [] -> do
       putStrLn "Couldn't find cabal_macros.h!"


### PR DESCRIPTION
Fixes #34.

- Bump various package versions. I needed to increase `hlint` upper bound quite a lot, due to various transitive dependencies via `hlint`. Otherwise no big jumps.
- Make some changes to appease hlint (I just applied them mindlessly, shout if you'd rather add pragmas to silence hlint
- Update Quickcheck usage to reflect added arguments, and use record syntax to avoid pragmas (let me know if this is unwanted for some reason)

Tests pass:

```
❯ cabal test all
Running 1 test suites...
Test suite doctests: RUNNING...
Running 1 test suites...
Test suite hlint: RUNNING...
Running 1 test suites...
Test suite properties: RUNNING...
Test suite properties: PASS
Test suite logged to:
/Users/elliotmarsden/elmo/src/ed25519/dist-newstyle/build/aarch64-osx/ghc-9.4.2/ed25519-0.0.5.0/t/properties/test/ed25519-0.0.5.0-properties.log
1 of 1 test suites (1 of 1 test cases) passed.
Test suite hlint: PASS
Test suite logged to:
/Users/elliotmarsden/elmo/src/ed25519/dist-newstyle/build/aarch64-osx/ghc-9.4.2/ed25519-0.0.5.0/t/hlint/test/ed25519-0.0.5.0-hlint.log
1 of 1 test suites (1 of 1 test cases) passed.
Test suite doctests: PASS
Test suite logged to:
/Users/elliotmarsden/elmo/src/ed25519/dist-newstyle/build/aarch64-osx/ghc-9.4.2/ed25519-0.0.5.0/t/doctests/test/ed25519-0.0.5.0-doctests.log
1 of 1 test suites (1 of 1 test cases) passed.
```