### PR TITLE
Fix secret key format produced by makeSecretKey

### DIFF
--- a/src/Crypto/Sign/Ed25519.hs
+++ b/src/Crypto/Sign/Ed25519.hs
@@ -311,9 +311,9 @@ openPublicKey (PublicKey xs) = xs
 --
 -- @since 0.0.6.0
 makeSecretKey :: ByteString -> Maybe SecretKey
-makeSecretKey xs
-  | S.length xs /= 32 = Nothing
-  | otherwise         = Just (SecretKey xs)
+-- The ed25519_sign_seed_keypair function uses the seed directly as the secret
+-- key, so the input here can just be passed to its Haskell wrapper.
+makeSecretKey xs = snd <$> createKeypairFromSeed_ xs
 
 -- | Return a 32-byte long @'ByteString'@ representing a
 -- @'SecretKey'@. This @'ByteString'@ is suitable for transmission and
@@ -321,7 +321,9 @@ makeSecretKey xs
 --
 -- @since 0.0.6.0
 openSecretKey :: SecretKey -> ByteString
-openSecretKey (SecretKey xs) = xs
+-- Internal representation of secret key uses 64 bytes, with the first 32 bytes
+-- being the actual secret key, followed by 32 bytes of public key.
+openSecretKey (SecretKey xs) = S.take 32 xs
 
 --------------------------------------------------------------------------------
 -- Default, non-detached API


### PR DESCRIPTION
Both the unrelying C implementation and also some other functions in this library (e.g. secretToPublicKey) expect the 64-byte internal representation of the secret key (i.e. 32 bytes of secret key, followed by 32 bytes of public key). Make sure the makeSecretKey produces SecretKey value in this form.

This fixes that before this change:
- for secret key generated by createKeypair, the combination "makeSecretKey . openSecretKey" returned "Nothing" instead of being equivalent to "Just"; and
- for a SecretKey created by makeSecretKey, the function secretToPublicKey returned PublicKey with empty data.

Fixes #45 